### PR TITLE
Adding Usersnap integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Public vars are available on server and client
 PUBLIC_SUPABASE="your-project.supabase.co"
 PUBLIC_SUPABASE_API_KEY="your-anonymous-key"
+USERSNAP_API_KEY="usersnap-api-key"
 
 # Non-public vars stay on the server
 ROOM_SECRET="your-room-secret"

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # Public vars are available on server and client
 PUBLIC_SUPABASE="your-project.supabase.co"
 PUBLIC_SUPABASE_API_KEY="your-anonymous-key"
-USERSNAP_API_KEY="usersnap-api-key"
+PUBLIC_USERSNAP_GLOBAL_API_KEY="usersnap-global-api-key"
+PUBLIC_USERSNAP_PROJECT_API_KEY="usersnap-project-api-key"
 
 # Non-public vars stay on the server
 ROOM_SECRET="your-room-secret"

--- a/src/apps/project-collaboration/InviteUsersToProject.tsx
+++ b/src/apps/project-collaboration/InviteUsersToProject.tsx
@@ -14,7 +14,7 @@ interface InviteUsersToProjectProps {
 
     project: Project,
 
-    user: UserProfile
+    user: UserProfile | undefined
 
 }
 
@@ -41,7 +41,7 @@ export const InviteUsersToProject = (props: InviteUsersToProjectProps) => {
 
         onSubmit: values => {
             console.log(values);
-            const invited_by_name = user.nickname ? user.nickname : user.last_name ? (user.first_name ? user.first_name + ' ' : '') + user.last_name : undefined;
+            const invited_by_name = user?.nickname ? user.nickname : user?.last_name ? (user.first_name ? user.first_name + ' ' : '') + user.last_name : undefined;
             inviteUserToProject(supabase, values.email, project.id, values.role, invited_by_name, project.name).then((result) => {
                 if (result?.error) {
                   console.error(result.error);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,6 +18,15 @@ const { title } = Astro.props;
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<meta name="view-transition" content="same-origin" />
+		<script
+		async
+		src='https://widget.usersnap.com/load/%USERSNAP_API_KEY%?onload=onUsersnapCXLoad'
+	  ></script>
+	  <script>
+		window.onUsersnapCXLoad = function(api) {
+		  api.init();
+		}
+	  </script>
 		<title>{title}</title>
 	</head>
 	<body>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -10,6 +10,7 @@ export interface Props {
 }
 
 const { title } = Astro.props;
+
 ---
 <!DOCTYPE html>
 <html lang={getLangFromUrl(Astro.url)}>
@@ -18,18 +19,19 @@ const { title } = Astro.props;
 		<meta name="viewport" content="width=device-width" />
 		<meta name="generator" content={Astro.generator} />
 		<meta name="view-transition" content="same-origin" />
-		<script
-		async
-		src='https://widget.usersnap.com/load/%USERSNAP_API_KEY%?onload=onUsersnapCXLoad'
-	  ></script>
-	  <script>
-		window.onUsersnapCXLoad = function(api) {
-		  api.init();
-		}
-	  </script>
 		<title>{title}</title>
 	</head>
 	<body>
 		<slot />
+		<script>
+			window.onUsersnapLoad = function(api) {
+			  api.init();
+			  api.show(import.meta.env.PUBLIC_USERSNAP_PROJECT_API_KEY);
+			}
+			var script = document.createElement('script');
+			script.defer = 1;
+			script.src = `https://widget.usersnap.com/global/load/${import.meta.env.PUBLIC_USERSNAP_GLOBAL_API_KEY}?onload=onUsersnapLoad`;
+			document.getElementsByTagName('head')[0].appendChild(script);
+		  </script>
 	</body>
 </html>


### PR DESCRIPTION
### What this does
Added a script in `BaseLayout.astro` to load the Usersnap feedback widget.
![image](https://github.com/recogito/unnamed-frontend/assets/110847635/e06320a7-99b7-4b27-8d1a-2e1bf5204ff9)
![image](https://github.com/recogito/unnamed-frontend/assets/110847635/8c1979bc-278e-44de-b333-8f1cf7788db5)
 

### Notes and further work
I have not yet done much to style the widget (other than making the background the same blue as the menu -- I tried to make it the right font but it doesn't seem to be loading correctly) or tweak its settings on the Usersnap side (for example I assume we don't want the field for choosing an assignee to show up), so there's plenty more to tinker with. It also currently is in the base layout so should show up on every page, but we can do something fancier with that as well.