### PR TITLE
Dashboard: 'Shared With Me' Filter

### DIFF
--- a/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
+++ b/src/apps/dashboard-projects/Empty/ProjectsEmpty.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { RocketLaunch } from '@phosphor-icons/react';
-import type { Project, Translations } from 'src/Types';
+import type { ExtendedProjectData, Translations } from 'src/Types';
 import { Button } from '@components/Button';
 import { initProject } from '@backend/helpers';
 import { supabase } from '@backend/supabaseBrowserClient';
@@ -9,7 +9,7 @@ export interface ProjectsEmptyProps {
 
   i18n: Translations;
 
-  onProjectCreated(project: Project): void;
+  onProjectCreated(project: ExtendedProjectData): void;
 
   onError(error: string): void;
 
@@ -28,7 +28,7 @@ export const ProjectsEmpty = (props: ProjectsEmptyProps) => {
     setFetching(true);
 
     initProject(supabase, t['Untitled Project'])
-      .then(({ project }) => {
+      .then(project => {
         props.onProjectCreated(project);
         setFetching(false);
       })

--- a/src/apps/dashboard-projects/Grid/ProjectsGrid.tsx
+++ b/src/apps/dashboard-projects/Grid/ProjectsGrid.tsx
@@ -1,15 +1,15 @@
 import { ProjectCard } from '@components/ProjectCard';
-import type { Project, Translations } from 'src/Types';
+import type { ExtendedProjectData, Translations } from 'src/Types';
 
 export interface ProjectsGridProps {
 
   i18n: Translations;
 
-  projects: Project[];
+  projects: ExtendedProjectData[];
 
-  onDeleteProject(project: Project): void;
+  onDeleteProject(project: ExtendedProjectData): void;
 
-  onRenameProject(project: Project): void;
+  onRenameProject(project: ExtendedProjectData): void;
 
 }
 

--- a/src/apps/dashboard-projects/Header/Header.tsx
+++ b/src/apps/dashboard-projects/Header/Header.tsx
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react';
 import { FunnelSimple, Kanban, MagnifyingGlass, Plus, User } from '@phosphor-icons/react';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { getMyProfile } from '@backend/crud';
+import { initProject } from '@backend/helpers';
 import { AccountActions } from '@components/AccountActions';
 import { Button } from '@components/Button';
 import { Notifications } from '@components/Notifications';
-import type { Invitation, MyProfile, Project, Translations } from 'src/Types';
+import type { Invitation, MyProfile, ExtendedProjectData, Translations } from 'src/Types';
 import { ProjectFilter } from '../ProjectsHome';
 
 import './Header.css';
-import { initProject } from '@backend/helpers';
 
 interface HeaderProps {
 
@@ -21,9 +21,9 @@ interface HeaderProps {
 
   onChangeFilter(f: ProjectFilter): void;
 
-  onProjectCreated(project: Project): void;
+  onProjectCreated(project: ExtendedProjectData): void;
 
-  onInvitationAccepted(invitation: Invitation, project: Project): void;
+  onInvitationAccepted(invitation: Invitation, project: ExtendedProjectData): void;
 
   onInvitationDeclined(invitation: Invitation): void;
 
@@ -49,7 +49,7 @@ export const Header = (props: HeaderProps) => {
     setCreating(true);
 
     initProject(supabase, t['Untitled Project'])
-      .then(({ project }) => {
+      .then(project => {
         props.onProjectCreated(project);
         setCreating(false);
       })

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -56,8 +56,8 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
       projects.filter(p => p.created_by.id === me.id) : 
     // Am I one of the users in the groups?
     filter === ProjectFilter.SHARED ? 
-      projects.filter(({ groups }) => 
-        groups.find(({ members }) => members.find(m => m.user.id === me.id))) : 
+      projects.filter(({ created_by, groups }) => 
+        groups.find(({ members }) => members.find(m => m.user.id === me.id) && me.id !== created_by.id)) : 
     [];
 
   const onProjectCreated = (project: ExtendedProjectData) =>

--- a/src/apps/dashboard-projects/ProjectsHome.tsx
+++ b/src/apps/dashboard-projects/ProjectsHome.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Hammer } from '@phosphor-icons/react';
-import type { Invitation, Project, Translations } from 'src/Types';
+import type { ExtendedProjectData, Invitation, Translations } from 'src/Types';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { deleteProject, getMyProfile } from '@backend/crud';
 import { ToastProvider, Toast, ToastContent } from '@components/Toast';
@@ -17,7 +17,7 @@ export interface ProjectsHomeProps {
 
   me: User;
 
-  projects: Project[];
+  projects: ExtendedProjectData[];
 
   invitations: Invitation[]; 
 
@@ -29,7 +29,9 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
 
   const { t } = props.i18n;
 
-  const [projects, setProjects] = useState<Project[]>(props.projects);
+  const { me } = props;
+
+  const [projects, setProjects] = useState<ExtendedProjectData[]>(props.projects);
 
   const [invitations, setInvitations] = useState<Invitation[]>(props.invitations);
 
@@ -46,18 +48,22 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
   }, []);
 
   const filteredProjects = 
+    // All projects
     filter === ProjectFilter.ALL ?
       projects : 
+    // Am I the creator?
     filter === ProjectFilter.MINE ? 
-      projects.filter(p => p.created_by.id === props.me.id) : 
+      projects.filter(p => p.created_by.id === me.id) : 
+    // Am I one of the users in the groups?
     filter === ProjectFilter.SHARED ? 
-      // TODO
-      [] : [];
+      projects.filter(({ groups }) => 
+        groups.find(({ members }) => members.find(m => m.user.id === me.id))) : 
+    [];
 
-  const onProjectCreated = (project: Project) =>
+  const onProjectCreated = (project: ExtendedProjectData) =>
     setProjects([...projects, project]);
 
-  const onRenameProject = (project: Project) => {
+  const onRenameProject = (project: ExtendedProjectData) => {
     setError({
       icon: <Hammer size={16} className="text-bottom" />,
       title: t['We\'re working on it!'],
@@ -66,7 +72,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
     });
   }
     
-  const onDeleteProject = (project: Project) =>
+  const onDeleteProject = (project: ExtendedProjectData) =>
     deleteProject(supabase, project.id).then(({ error, data }) => {
       if (error) {
         console.error(error);
@@ -94,7 +100,7 @@ export const ProjectsHome = (props: ProjectsHomeProps) => {
       type: 'error'
     });
 
-  const onInvitationAccepted = (invitation: Invitation, project: Project) => {
+  const onInvitationAccepted = (invitation: Invitation, project: ExtendedProjectData) => {
     setInvitations(invitations => invitations.filter(i => i.id !== invitation.id));
     setProjects(projects => ([ project, ...projects ]));
   }

--- a/src/backend/helpers/invitationHelpers.ts
+++ b/src/backend/helpers/invitationHelpers.ts
@@ -1,10 +1,11 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { Invitation, Project } from 'src/Types';
+import type { ExtendedProjectData, Invitation } from 'src/Types';
+import { getProjectExtended } from './projectHelpers';
 
 export const joinProject = (
   supabase: SupabaseClient, 
   invitation: Invitation
-): Promise<Project> => new Promise((resolve, reject) => {
+): Promise<ExtendedProjectData> => new Promise((resolve, reject) => {
   supabase
     .from('invites')
     .update({ accepted: true })
@@ -13,23 +14,12 @@ export const joinProject = (
       if (error) {
         reject(error);
       } else {
-        supabase
-          .from('projects')
-          .select(`
-            id,
-            created_at,
-            updated_at,
-            updated_by,
-            name,
-            description
-          `)
-          .eq('id', invitation.project_id)
-          .maybeSingle()
+        getProjectExtended(supabase, invitation.project_id)
           .then(({ error, data }) => {
             if (error || !data)
               reject(error);
             else 
-              resolve(data as Project);
+              resolve(data);
           });
       }
     });

--- a/src/components/Notifications/InvitationItem/InvitationItem.tsx
+++ b/src/components/Notifications/InvitationItem/InvitationItem.tsx
@@ -3,7 +3,7 @@ import { TimeAgo } from '@components/TimeAgo';
 import { supabase } from '@backend/supabaseBrowserClient';
 import { Button } from '@components/Button';
 import { declineInvitation, joinProject } from '@backend/helpers/invitationHelpers';
-import type { Invitation, Project, Translations } from 'src/Types';
+import type { Invitation, ExtendedProjectData, Translations } from 'src/Types';
 
 import './InvitationItem.css';
 
@@ -13,7 +13,7 @@ interface InvitationItemProps {
 
   invitation: Invitation;
 
-  onAccepted(project: Project): void;
+  onAccepted(project: ExtendedProjectData): void;
 
   onDeclined(): void;
 

--- a/src/components/Notifications/Notifications.tsx
+++ b/src/components/Notifications/Notifications.tsx
@@ -1,6 +1,6 @@
 import * as Popover from '@radix-ui/react-popover';
 import { Bell, X } from '@phosphor-icons/react';
-import type { Invitation, Project, Translations } from 'src/Types';
+import type { ExtendedProjectData, Invitation, Translations } from 'src/Types';
 import { EmptyList } from './EmptyList';
 import { InvitationItem } from './InvitationItem';
 
@@ -14,7 +14,7 @@ interface NotificationsProps {
 
   invitations: Invitation[];
 
-  onInvitationAccepted(invitation: Invitation, project: Project): void;
+  onInvitationAccepted(invitation: Invitation, project: ExtendedProjectData): void;
 
   onInvitationDeclined(invitation: Invitation): void;
 

--- a/src/pages/[lang]/projects/index.astro
+++ b/src/pages/[lang]/projects/index.astro
@@ -2,11 +2,10 @@
 import BaseLayout from '@layouts/BaseLayout.astro';
 import { createSupabaseServerClient } from '@backend/supabaseServerClient';
 import { getLangFromUrl, getTranslations } from '@i18n';
-import { listMyInvites, listMyProjects } from '@backend/crud';
+import { listMyInvites } from '@backend/crud';
 import { ProjectsHome } from '@apps/dashboard-projects';
 import { getUser } from '@backend/auth';
 import { listMyProjectsExtended } from '@backend/helpers';
-import type { ExtendedProjectData } from 'src/Types';
 
 const lang = getLangFromUrl(Astro.url);
 
@@ -16,8 +15,7 @@ if (!supabase)
 
 const me = await getUser(supabase);
 
-// const projects = await listMyProjectsExtended(supabase);
-const projects = await listMyProjects(supabase);
+const projects = await listMyProjectsExtended(supabase);
 
 const invitations = await listMyInvites(supabase);
 


### PR DESCRIPTION
## In this PR

This PR adds the "Shared With Me" filter tab option to the dashboard, which enables users to see only projects that they were invited to (but exclude projects they have created themselves; and projects that they are unrelated to, but might see because they have a system-wide admin role).

All uses of the basic `Project` type are replaced with `ExtendedProjectData`. While `Project` is simply a direct representation of the `projects` DB table record, `ExtendedProjectData` is a more complex data type. [See here for TS interface definition](https://github.com/recogito/unnamed-frontend/blob/main/src/Types.ts#L47-L102).

ExtendedProjectData includes:
- the creator profile (included via JOIN)
- project contexts (included via JOIN)
- project layers and documents (included via nested JOIN)
- project groups (included via JOIN)
- project group members (included via a follow-up query on the `group_users` table, with a JOIN on `profiles`)
  - there is additional client-side processing of the result that inlines the member profiles into the result object

### TODOs/Challenges

In the future, as projects get bigger, it may not be feasible (or performant enough) to retrieve __all project members__. (E.g. if there are 100s?). If we limit the number of users to return from the DB, the above approach will break. Instead, we'd need to modify the `ExtendedProjetData` object, and figure out a way to retrieve, for example, the following information from the DB:
- The first N members for each project in a list of projects  
- The total count of members per project
- A flag indicating whether my user is a member in a project

__Important!__ At the moment, `Student` member with no Org role cannot see groups - which means this feature __will currently not work for them__, and their projects will not show up under 'Shared with me'.   